### PR TITLE
Pass kwargs through from_xls and from_xlsx to agate.Table

### DIFF
--- a/agateexcel/table_xls.py
+++ b/agateexcel/table_xls.py
@@ -10,7 +10,7 @@ import agate
 import six
 import xlrd
 
-def from_xls(cls, path, sheet=None):
+def from_xls(cls, path, sheet=None, **kwargs):
     """
     Parse an XLS file.
 
@@ -57,7 +57,7 @@ def from_xls(cls, path, sheet=None):
     for i in range(len(columns[0])):
         rows.append([c[i] for c in columns])
 
-    return agate.Table(rows, column_names)
+    return agate.Table(rows, column_names, **kwargs)
 
 def determine_excel_type(types):
     """

--- a/agateexcel/table_xlsx.py
+++ b/agateexcel/table_xlsx.py
@@ -12,7 +12,7 @@ import six
 
 NULL_TIME = datetime.time(0, 0, 0)
 
-def from_xlsx(cls, path, sheet=None):
+def from_xlsx(cls, path, sheet=None, **kwargs):
     """
     Parse an XLSX file.
 
@@ -66,7 +66,7 @@ def from_xlsx(cls, path, sheet=None):
 
     f.close()
 
-    return agate.Table(rows, column_names)
+    return agate.Table(rows, column_names, **kwargs)
 
 def normalize_datetime(dt):
     if dt.microsecond == 0:


### PR DESCRIPTION
Closes #6.

Without this, for example, csvkit can't turn off type inference when converting from Excel.