### PR TITLE
Update python versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to install dependencies
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -r requirements-py3.txt; else pip install -r requirements-py2.txt; fi


### PR DESCRIPTION
Remove Python 3.3 because Nose requires 3.4 or greater.  We also add Python 3.6.  Default Travis test runners don't support 3.7, but it can be added by specifying `dist: xenial`

This should resolve test failures for pull requests 25 and 27.