### PR TITLE
The finally clause needs 'book' to be defined

### DIFF
--- a/agateexcel/table_xls.py
+++ b/agateexcel/table_xls.py
@@ -40,13 +40,13 @@ def from_xls(cls, path, sheet=None, skip_lines=0, header=True, encoding_override
     if not isinstance(skip_lines, int):
         raise ValueError('skip_lines argument must be an int')
 
-    try:
-       if hasattr(path, 'read'):
-           book = xlrd.open_workbook(file_contents=path.read(), encoding_override=encoding_override, on_demand=True)
-       else:
-           with open(path, 'rb') as f:
-               book = xlrd.open_workbook(file_contents=f.read(), encoding_override=encoding_override, on_demand=True)
+    if hasattr(path, 'read'):
+        book = xlrd.open_workbook(file_contents=path.read(), encoding_override=encoding_override, on_demand=True)
+    else:
+        with open(path, 'rb') as f:
+            book = xlrd.open_workbook(file_contents=f.read(), encoding_override=encoding_override, on_demand=True)
 
+    try:
        multiple = agate.utils.issequence(sheet)
        if multiple:
            sheets = sheet


### PR DESCRIPTION
Avoids:
```
  File "/usr/local/lib/python3.8/site-packages/agateexcel/table_xls.py", line 128, in from_xls
    book.release_resources()
UnboundLocalError: local variable 'book' referenced before assignment
```
when:
```
  File "/usr/local/lib/python3.8/site-packages/agateexcel/table_xls.py", line 52, in from_xls
    book = xlrd.open_workbook(file_contents=path.read(), encoding_override=encoding_override, on_demand=True)
```
fails, i.e. when we encounter a xlrd.compdoc.CompDocError: Workbook corruption.